### PR TITLE
[codex] Add created_by to order items

### DIFF
--- a/config/connectDB.go
+++ b/config/connectDB.go
@@ -12,7 +12,7 @@ var DB *gorm.DB
 
 func ConnectDB(config *Config) {
 	var err error
-	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable TimeZone=Asia/Shanghai", config.DBHost, config.DBUserName, config.DBUserPassword, config.DBName, config.DBPort)
+	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d sslmode=disable TimeZone=Asia/Shanghai", config.DBHost, config.DBUserName, config.DBUserPassword, config.DBName, config.DBPort)
 
 	DB, err = gorm.Open(postgres.Open(dsn))
 	if err != nil {

--- a/storage/migrations/postgres/006_add_created_by_to_order_items.down.sql
+++ b/storage/migrations/postgres/006_add_created_by_to_order_items.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "order_items"
+DROP COLUMN IF EXISTS "created_by";

--- a/storage/migrations/postgres/006_add_created_by_to_order_items.up.sql
+++ b/storage/migrations/postgres/006_add_created_by_to_order_items.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "order_items"
+ADD COLUMN IF NOT EXISTS "created_by" BIGINT;

--- a/storage/postgres/order_item.go
+++ b/storage/postgres/order_item.go
@@ -33,7 +33,8 @@ func (stg orderItemRepo) Create(userID int64, entity models.CreateOrderItemModel
 		status,
 		description,
 		is_countable,
-		order_item_type_id
+		order_item_type_id,
+		created_by
 	) VALUES (
 		$1,
 		$2,
@@ -43,7 +44,8 @@ func (stg orderItemRepo) Create(userID int64, entity models.CreateOrderItemModel
 		$6,
 		$7,
 		$8,
-		$9
+		$9,
+		$10
 	) RETURNING id`,
 		entity.OrderID,
 		entity.ItemType,
@@ -54,6 +56,7 @@ func (stg orderItemRepo) Create(userID int64, entity models.CreateOrderItemModel
 		entity.Description,
 		entity.IsCountable,
 		entity.OrderItemTypeID,
+		userID,
 	).Scan(&id)
 
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `created_by` column migration for `order_items`
- store the current authenticated user ID when creating an order item
- fix the DB port format string so `go test ./...` passes vet

## Validation
- `go test ./...`
